### PR TITLE
Refactor footer config and layout

### DIFF
--- a/src/Footer/Component.tsx
+++ b/src/Footer/Component.tsx
@@ -2,33 +2,69 @@ import { getCachedGlobal } from '@/utilities/getGlobals'
 import Link from 'next/link'
 import React from 'react'
 
-import type { Footer } from '@/payload-types'
-
+import * as Icons from 'lucide-react'
 import { ThemeSelector } from '@/providers/Theme/ThemeSelector'
 import { CMSLink } from '@/components/Link'
 import { Logo } from '@/components/Logo/Logo'
+import { CallToActionBlock } from '@/blocks/CallToAction/Component'
 
 export async function Footer() {
-  const footerData: Footer = await getCachedGlobal('footer', 1)()
+  const footerData: any = await getCachedGlobal('footer', 2)()
 
-  const navItems = footerData?.navItems || []
+  const columns = footerData?.columns || []
+  const socialLinks = footerData?.logoSection?.socialLinks || []
 
   return (
-    <footer className="mt-auto border-t border-border bg-black dark:bg-card text-white">
-      <div className="container py-8 gap-8 flex flex-col md:flex-row md:justify-between">
-        <Link className="flex items-center" href="/">
-          <Logo />
-        </Link>
-
-        <div className="flex flex-col-reverse items-start md:flex-row gap-4 md:items-center">
-          <ThemeSelector />
-          <nav className="flex flex-col md:flex-row gap-4">
-            {navItems.map(({ link }, i) => {
-              return <CMSLink className="text-white" key={i} {...link} />
-            })}
-          </nav>
+    <>
+      {footerData?.cta && (
+        <div className="mb-8">
+          <CallToActionBlock {...footerData.cta} />
         </div>
-      </div>
-    </footer>
+      )}
+      <footer className="mt-auto border-t border-border bg-black dark:bg-card text-white">
+        <div className="container py-8 flex flex-col gap-8">
+          <div className="grid gap-8 md:grid-cols-4">
+            <div className="flex flex-col gap-4">
+              <Link className="flex" href="/">
+                <Logo />
+              </Link>
+              {footerData?.logoSection?.text && (
+                <p className="text-sm">{footerData.logoSection.text}</p>
+              )}
+              <div className="flex gap-3 items-center">
+                {socialLinks.map(({ icon, link }, i) => {
+                  const Icon = Icons[icon as keyof typeof Icons]
+                  return (
+                    <CMSLink key={i} {...link} className="text-white">
+                      {Icon ? <Icon className="w-5 h-5" /> : icon}
+                    </CMSLink>
+                  )
+                })}
+              </div>
+            </div>
+            {columns.map(({ label, links }: any, i: number) => (
+              <div key={i} className="flex flex-col gap-2">
+                {label && <p className="font-bold mb-2">{label}</p>}
+                {(links || []).map(({ link: columnLink }: any, li: number) => (
+                  <CMSLink key={li} className="text-white" {...columnLink} />
+                ))}
+              </div>
+            ))}
+          </div>
+          <div className="border-t border-border pt-4 mt-8 flex flex-col md:flex-row md:justify-between text-sm gap-4">
+            <p>{footerData?.bottom?.copyright}</p>
+            <div className="flex gap-4 md:justify-end">
+              {footerData?.bottom?.legal?.privacyPolicy && (
+                <CMSLink className="text-white" {...footerData.bottom.legal.privacyPolicy} />
+              )}
+              {footerData?.bottom?.legal?.termsAndConditions && (
+                <CMSLink className="text-white" {...footerData.bottom.legal.termsAndConditions} />
+              )}
+              <ThemeSelector />
+            </div>
+          </div>
+        </div>
+      </footer>
+    </>
   )
 }

--- a/src/Footer/config.ts
+++ b/src/Footer/config.ts
@@ -1,6 +1,8 @@
 import type { GlobalConfig } from 'payload'
 
 import { link } from '@/fields/link'
+import { linkGroup } from '@/fields/linkGroup'
+import { socialLinkGroup } from '@/fields/socialLinkGroup'
 import { revalidateFooter } from './hooks/revalidateFooter'
 
 export const Footer: GlobalConfig = {
@@ -10,20 +12,61 @@ export const Footer: GlobalConfig = {
   },
   fields: [
     {
-      name: 'navItems',
-      type: 'array',
+      name: 'cta',
+      type: 'group',
       fields: [
+        {
+          name: 'richText',
+          type: 'richText',
+        },
         link({
-          appearances: false,
+          appearances: ['default', 'outline'],
+          overrides: { name: 'link' },
         }),
       ],
-      maxRows: 6,
+    },
+    {
+      name: 'logoSection',
+      type: 'group',
+      fields: [
+        {
+          name: 'text',
+          type: 'textarea',
+        },
+        socialLinkGroup(),
+      ],
+    },
+    {
+      name: 'columns',
+      type: 'array',
+      fields: [
+        {
+          name: 'label',
+          type: 'text',
+        },
+        linkGroup(),
+      ],
       admin: {
         initCollapsed: true,
-        components: {
-          RowLabel: '@/Footer/RowLabel#RowLabel',
-        },
       },
+    },
+    {
+      name: 'bottom',
+      type: 'group',
+      fields: [
+        {
+          name: 'copyright',
+          type: 'text',
+        },
+        {
+          name: 'legal',
+          type: 'group',
+          fields: [
+            link({ overrides: { name: 'privacyPolicy' } }),
+            link({ overrides: { name: 'termsAndConditions' } }),
+          ],
+        },
+      ],
     },
   ],
   hooks: {

--- a/src/endpoints/seed/index.ts
+++ b/src/endpoints/seed/index.ts
@@ -310,31 +310,101 @@ export const seed = async ({
     payload.updateGlobal({
       slug: 'footer',
       data: {
-        navItems: [
-          {
-            link: {
-              type: 'custom',
-              label: 'Admin',
-              url: '/admin',
+        cta: {
+          richText: {
+            root: {
+              type: 'root',
+              children: [
+                {
+                  type: 'paragraph',
+                  children: [
+                    {
+                      type: 'text',
+                      text: 'Ready to get started?',
+                      detail: 0,
+                      format: 0,
+                      mode: 'normal',
+                      style: '',
+                      version: 1,
+                    },
+                  ],
+                  direction: 'ltr',
+                  format: '',
+                  indent: 0,
+                  version: 1,
+                },
+              ],
+              direction: 'ltr',
+              format: '',
+              indent: 0,
+              version: 1,
             },
           },
-          {
-            link: {
-              type: 'custom',
-              label: 'Source Code',
-              newTab: true,
-              url: 'https://github.com/payloadcms/payload/tree/main/templates/website',
+          link: {
+            type: 'custom',
+            appearance: 'default',
+            label: 'Contact Us',
+            url: '/contact',
+          },
+        },
+        logoSection: {
+          text: 'Short text about the company.',
+          socialLinks: [
+            {
+              icon: 'Facebook',
+              link: {
+                type: 'custom',
+                url: 'https://facebook.com',
+                label: 'Facebook',
+              },
             },
+            {
+              icon: 'Twitter',
+              link: {
+                type: 'custom',
+                url: 'https://twitter.com',
+                label: 'Twitter',
+              },
+            },
+          ],
+        },
+        columns: [
+          {
+            label: 'Company',
+            links: [
+              { link: { type: 'custom', label: 'About', url: '/about' } },
+              { link: { type: 'custom', label: 'Blog', url: '/posts' } },
+            ],
           },
           {
-            link: {
-              type: 'custom',
-              label: 'Payload',
-              newTab: true,
-              url: 'https://payloadcms.com/',
-            },
+            label: 'Help',
+            links: [
+              { link: { type: 'custom', label: 'Contact', url: '/contact' } },
+              { link: { type: 'custom', label: 'Support', url: '/support' } },
+            ],
+          },
+          {
+            label: 'More',
+            links: [
+              { link: { type: 'custom', label: 'Admin', url: '/admin' } },
+            ],
           },
         ],
+        bottom: {
+          copyright: '© Payload 2025',
+          legal: {
+            privacyPolicy: {
+              type: 'custom',
+              label: 'Privacy Policy',
+              url: '/privacy',
+            },
+            termsAndConditions: {
+              type: 'custom',
+              label: 'Terms',
+              url: '/terms',
+            },
+          },
+        },
       },
     }),
   ])

--- a/src/fields/socialLinkGroup.ts
+++ b/src/fields/socialLinkGroup.ts
@@ -1,0 +1,30 @@
+import type { ArrayField, Field } from 'payload'
+
+import type { LinkAppearances } from './link'
+import deepMerge from '@/utilities/deepMerge'
+import { link } from './link'
+
+export type SocialLinkGroupArgs = {
+  appearances?: LinkAppearances[] | false
+  overrides?: Partial<ArrayField>
+}
+
+export const socialLinkGroup = ({ appearances, overrides = {} }: SocialLinkGroupArgs = {}): Field => {
+  const socialLinks: Field = {
+    name: 'socialLinks',
+    type: 'array',
+    fields: [
+      {
+        name: 'icon',
+        type: 'text',
+        required: true,
+      },
+      link({ appearances }),
+    ],
+    admin: {
+      initCollapsed: true,
+    },
+  }
+
+  return deepMerge(socialLinks, overrides)
+}


### PR DESCRIPTION
## Summary
- add `socialLinkGroup` field for social icon links
- overhaul footer config with CTA, social links, link columns and legal links
- render updated footer layout and CTA
- seed new footer data demonstrating the structure

## Testing
- `pnpm lint` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_685555502e8c832ca764ceebc1cf788e