### PR TITLE
Add form relationship to high impact hero

### DIFF
--- a/src/heros/HighImpact/index.tsx
+++ b/src/heros/HighImpact/index.tsx
@@ -7,8 +7,9 @@ import type { Page } from '@/payload-types'
 import { CMSLink } from '@/components/Link'
 import { Media } from '@/components/Media'
 import RichText from '@/components/RichText'
+import { FormBlock } from '@/blocks/Form/Component'
 
-export const HighImpactHero: React.FC<Page['hero']> = ({ links, media, richText }) => {
+export const HighImpactHero: React.FC<Page['hero']> = ({ links, media, richText, form }) => {
   const { setHeaderTheme } = useHeaderTheme()
 
   useEffect(() => {
@@ -45,11 +46,11 @@ export const HighImpactHero: React.FC<Page['hero']> = ({ links, media, richText 
         </div>
       </div>
 
-      {/* Bottom Section Placeholder (e.g., for 20vh contact form) */}
-      <div className="h-[30vh] max-w-screen-xl mx-auto flex items-center justify-center bg-brand-dark">
-        {/* Replace this with your contact form */}
-        <p className="text-lg text-brand-light">[ Contact form goes here... ]</p>
-      </div>
+      {form && typeof form === 'object' && (
+        <div className="py-8 bg-brand-dark">
+          <FormBlock form={form} enableIntro={false} />
+        </div>
+      )}
     </div>
   )
 }

--- a/src/heros/config.ts
+++ b/src/heros/config.ts
@@ -67,6 +67,15 @@ export const hero: Field = {
       relationTo: 'media',
       required: true,
     },
+    {
+      name: 'form',
+      label: 'Form',
+      type: 'relationship',
+      relationTo: 'forms',
+      admin: {
+        condition: (_, { type }) => type === 'highImpact',
+      },
+    },
   ],
   label: false,
 }

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -193,8 +193,9 @@ export interface Page {
           id?: string | null;
         }[]
       | null;
-    media?: (number | null) | Media;
-  };
+      media?: (number | null) | Media;
+      form?: (number | null) | Form;
+    };
   layout: (CallToActionBlock | ContentBlock | MediaBlock | ArchiveBlock | FormBlock)[];
   meta?: {
     title?: string | null;
@@ -1061,9 +1062,10 @@ export interface PagesSelect<T extends boolean = true> {
                     label?: T;
                     appearance?: T;
                   };
-              id?: T;
-            };
+            id?: T;
+          };
         media?: T;
+        form?: T;
       };
   layout?:
     | T


### PR DESCRIPTION
## Summary
- allow selecting a form in hero config
- render a selected form in HighImpactHero
- include form in generated Payload types

## Testing
- `npm run generate:types` *(fails: `cross-env` not found)*
- `npm run lint` *(fails: `cross-env` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e40536e24832ca3dbae4a15ef4521