### PR TITLE
Refactor to simple static website

### DIFF
--- a/src/Footer/Component.tsx
+++ b/src/Footer/Component.tsx
@@ -1,29 +1,34 @@
-import { getCachedGlobal } from '@/utilities/getGlobals'
-import { getFooterServices } from '@/utilities/getServices'
 import Link from 'next/link'
 import React from 'react'
 
-import { FaInstagram } from 'react-icons/fa'
-import { FaFacebookF } from 'react-icons/fa'
-import { FaYoutube } from 'react-icons/fa'
+import { FaInstagram, FaFacebookF, FaYoutube } from 'react-icons/fa'
 
-import type { Footer } from '@/payload-types'
+import type { Footer as FooterType } from '@/payload-types'
 
 import { CMSLink } from '@/components/Link'
 import { Logo } from '@/components/Logo/Logo'
 
 export async function Footer() {
-  const footerData: Footer = await getCachedGlobal('footer', 1)()
-  const services = await getFooterServices(5)
+  const footerData: FooterType = {
+    navItems: [
+      { link: { url: '/', label: 'Home', type: 'custom' } },
+      { link: { url: '/about-us', label: 'About Us', type: 'custom' } },
+      { link: { url: '/dr-serhat', label: 'Dr. Serhat', type: 'custom' } },
+      { link: { url: '/services', label: 'Services', type: 'custom' } },
+      { link: { url: '/contact-us', label: 'Contact Us', type: 'custom' } },
+    ],
+  } as FooterType
+
+  const services = [
+    { id: '1', title: 'Service One', slug: 'service-one' },
+    { id: '2', title: 'Service Two', slug: 'service-two' },
+    { id: '3', title: 'Service Three', slug: 'service-three' },
+  ]
 
   const navItems = footerData?.navItems || []
 
   return (
     <footer className="relative overflow-hidden font-body text-white bg-gradient-to-t from-brand-dark to-transparent">
-      {/* Background image (optional) */}
-      {/* <div className="absolute inset-0 bg-cover bg-no-repeat bg-center" style={{ backgroundImage: "url('')", zIndex: 0 }}></div> */}
-
-      {/* Call to Action Section */}
       <div className="bg-brand-primary text-brand-dark py-10 px-6 md:px-20 mx-4 md:mx-12 lg:mx-26 2xl:mx-52 relative z-10">
         <div className=" max-w-screen-xl mx-auto flex flex-col md:flex-row justify-between items-center gap-6">
           <div className="text-center md:text-left md:max-w-md max-w-sm">
@@ -38,13 +43,10 @@ export async function Footer() {
         </div>
       </div>
 
-      {/* Footer Main Section */}
       <div className="py-12 px-6 md:px-20 relative z-10">
         <div className="max-w-screen-xl mx-auto grid grid-cols-1 md:grid-cols-4 gap-10">
-          {/* Logo Section */}
           <div>
             <div className="mb-4">
-              {/* Replace with actual logo image or SVG */}
               <Logo className="h-auto mb-2" />
             </div>
             <p className="text-sm text-gray-300 mb-4">
@@ -79,7 +81,6 @@ export async function Footer() {
             </div>
           </div>
 
-          {/* Links Column */}
           <div>
             <h3 className="font-bold mb-3 font-heading">Our Pages</h3>
             <nav className="flex flex-col space-y-2 text-sm text-brand-white hover:text-brand-primary">
@@ -89,7 +90,6 @@ export async function Footer() {
             </nav>
           </div>
 
-          {/* Services Column */}
           <div>
             <h3 className="font-bold mb-3 font-heading">Services</h3>
             <ul className="space-y-2 text-sm text-brand-white">
@@ -101,7 +101,6 @@ export async function Footer() {
             </ul>
           </div>
 
-          {/* Contact Us Column */}
           <div>
             <h3 className="font-bold mb-3 font-heading ">Contact Us </h3>
             <ul className="space-y-2 text-sm text">
@@ -125,7 +124,6 @@ export async function Footer() {
         </div>
       </div>
 
-      {/* Footer Bottom */}
       <div className="border-t border-brand-primary text-sm py-4 px-6 md:px-20 relative z-10">
         <div className="max-w-screen-xl mx-auto flex flex-col md:flex-row justify-between items-center">
           <p className="text-gray-400">
@@ -142,9 +140,6 @@ export async function Footer() {
           </div>
         </div>
       </div>
-
-      {/* Optional Decorative Lines */}
-      {/* Use absolutely positioned divs or SVGs for lines if needed */}
     </footer>
   )
 }

--- a/src/Header/Component.tsx
+++ b/src/Header/Component.tsx
@@ -1,11 +1,17 @@
 import { HeaderClient } from './Component.client'
-import { getCachedGlobal } from '@/utilities/getGlobals'
 import React from 'react'
-
 import type { Header } from '@/payload-types'
 
 export async function Header() {
-  const headerData: Header = await getCachedGlobal('header', 1)()
+  const headerData: Header = {
+    navItems: [
+      { link: { url: '/', label: 'Home', type: 'custom' } },
+      { link: { url: '/about-us', label: 'About Us', type: 'custom' } },
+      { link: { url: '/dr-serhat', label: 'Dr. Serhat', type: 'custom' } },
+      { link: { url: '/services', label: 'Services', type: 'custom' } },
+      { link: { url: '/contact-us', label: 'Contact Us', type: 'custom' } },
+    ],
+  } as Header
 
   return <HeaderClient data={headerData} />
 }

--- a/src/app/(frontend)/about-us/page.tsx
+++ b/src/app/(frontend)/about-us/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next'
+import React from 'react'
+
+export const metadata: Metadata = {
+  title: 'About Us | Primedent',
+}
+
+export default function AboutUsPage() {
+  return (
+    <main className="container py-24">
+      <h1 className="text-3xl font-bold mb-4">About Us</h1>
+      <p>This page describes information about the clinic. Update this text with your own content.</p>
+    </main>
+  )
+}

--- a/src/app/(frontend)/contact-us/page.tsx
+++ b/src/app/(frontend)/contact-us/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next'
+import React from 'react'
+
+export const metadata: Metadata = {
+  title: 'Contact Us | Primedent',
+}
+
+export default function ContactUsPage() {
+  return (
+    <main className="container py-24">
+      <h1 className="text-3xl font-bold mb-4">Contact Us</h1>
+      <p>Feel free to reach out to us using the information on this page.</p>
+    </main>
+  )
+}

--- a/src/app/(frontend)/dr-serhat/page.tsx
+++ b/src/app/(frontend)/dr-serhat/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next'
+import React from 'react'
+
+export const metadata: Metadata = {
+  title: 'Dr. Serhat | Primedent',
+}
+
+export default function DrSerhatPage() {
+  return (
+    <main className="container py-24">
+      <h1 className="text-3xl font-bold mb-4">Dr. Serhat</h1>
+      <p>Introduce Dr. Serhat here. Replace this text with the doctor's biography.</p>
+    </main>
+  )
+}

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -1,5 +1,15 @@
-import PageTemplate, { generateMetadata } from './[slug]/page'
+import type { Metadata } from 'next'
+import React from 'react'
 
-export default PageTemplate
+export const metadata: Metadata = {
+  title: 'Home | Primedent',
+}
 
-export { generateMetadata }
+export default function Page() {
+  return (
+    <main className="container py-24">
+      <h1 className="text-3xl font-bold mb-4">Welcome to Primedent</h1>
+      <p>This is a placeholder homepage. Replace this content with your own.</p>
+    </main>
+  )
+}

--- a/src/app/(frontend)/services/page.tsx
+++ b/src/app/(frontend)/services/page.tsx
@@ -1,63 +1,27 @@
-import type { Metadata } from 'next/types'
-
-import { CollectionArchive } from '@/components/CollectionArchive'
-import { PageRange } from '@/components/PageRange'
-import { Pagination } from '@/components/Pagination'
-import configPromise from '@payload-config'
-import { getPayload } from 'payload'
+import type { Metadata } from 'next'
 import React from 'react'
-import PageClient from './page.client'
 
-export const dynamic = 'force-static'
-export const revalidate = 600
-
-export default async function Page() {
-  const payload = await getPayload({ config: configPromise })
-
-  const posts = await payload.find({
-    collection: 'services',
-    depth: 1,
-    limit: 12,
-    overrideAccess: false,
-    select: {
-      title: true,
-      slug: true,
-      categories: true,
-      meta: true,
-    },
-  })
-
-  return (
-    <div className="pt-24 pb-24">
-      <PageClient />
-      <div className="container mb-16">
-        <div className="prose dark:prose-invert max-w-none">
-          <h1>Services</h1>
-        </div>
-      </div>
-
-      <div className="container mb-8">
-        <PageRange
-          collection="services"
-          currentPage={posts.page}
-          limit={12}
-          totalDocs={posts.totalDocs}
-        />
-      </div>
-
-      <CollectionArchive posts={posts.docs} />
-
-      <div className="container">
-        {posts.totalPages > 1 && posts.page && (
-          <Pagination page={posts.page} totalPages={posts.totalPages} />
-        )}
-      </div>
-    </div>
-  )
+export const metadata: Metadata = {
+  title: 'Services | Primedent',
 }
 
-export function generateMetadata(): Metadata {
-  return {
-    title: `Payload Website Template Services`,
-  }
+export default function ServicesPage() {
+  const services = [
+    { title: 'Service One', slug: 'service-one' },
+    { title: 'Service Two', slug: 'service-two' },
+    { title: 'Service Three', slug: 'service-three' },
+  ]
+
+  return (
+    <main className="container py-24">
+      <h1 className="text-3xl font-bold mb-8">Services</h1>
+      <ul className="space-y-2">
+        {services.map((service) => (
+          <li key={service.slug} className="underline">
+            <a href={`/services/${service.slug}`}>{service.title}</a>
+          </li>
+        ))}
+      </ul>
+    </main>
+  )
 }


### PR DESCRIPTION
## Summary
- switch header and footer to use hard-coded nav items
- replace dynamic CMS pages with static pages
- add placeholder pages for About Us, Contact Us, Dr. Serhat and Services

## Testing
- `npm run lint` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e6bd7d2a4832c87c19cfd0be85950