### PR TITLE
Fix hero image on post archive

### DIFF
--- a/src/app/(frontend)/posts/page.tsx
+++ b/src/app/(frontend)/posts/page.tsx
@@ -24,6 +24,7 @@ export default async function Page() {
       slug: true,
       categories: true,
       meta: true,
+      heroImage: true,
     },
   })
 

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -8,7 +8,8 @@ import type { Post, Service } from '@/payload-types'
 
 import { Media } from '@/components/Media'
 
-export type CardPostData = Pick<Post, 'slug' | 'categories' | 'meta' | 'title'>
+export type CardPostData =
+  Pick<Post, 'slug' | 'categories' | 'meta' | 'title' | 'heroImage'>
 export type CardServiceData = Pick<Service, 'slug' | 'categories' | 'meta' | 'title'>
 
 type CardProps = {
@@ -24,8 +25,9 @@ export const Card: React.FC<CardProps> = (props) => {
   const { card, link } = useClickableCard({})
   const { className, doc, relationTo, showCategories, title: titleFromProps } = props
 
-  const { slug, categories, meta, title } = doc || {}
+  const { slug, categories, meta, title, heroImage } = doc || {}
   const { description, image: metaImage } = meta || {}
+  const imageToUse = metaImage || heroImage
 
   const hasCategories = categories && Array.isArray(categories) && categories.length > 0
   const titleToUse = titleFromProps || title
@@ -41,8 +43,10 @@ export const Card: React.FC<CardProps> = (props) => {
       ref={card.ref}
     >
       <div className="relative w-full ">
-        {!metaImage && <div className="">No image</div>}
-        {metaImage && typeof metaImage !== 'string' && <Media resource={metaImage} size="33vw" />}
+        {!imageToUse && <div className="">No image</div>}
+        {imageToUse && typeof imageToUse !== 'string' && (
+          <Media resource={imageToUse} size="33vw" />
+        )}
       </div>
       <div className="p-4">
         {showCategories && hasCategories && (


### PR DESCRIPTION
## Summary
- expose the `heroImage` field in `CardPostData`
- render hero image in the `<Card>` component
- select `heroImage` when fetching posts for the archive page

## Testing
- `npm run lint` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878e6c047a8832cb1b76d06ec22c628