### PR TITLE
Add hero image fallback and query updates

### DIFF
--- a/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/posts/[slug]/page.tsx
@@ -94,6 +94,18 @@ const queryPostBySlug = cache(async ({ slug }: { slug: string }) => {
     draft,
     limit: 1,
     overrideAccess: draft,
+    depth: 1,
+    select: {
+      title: true,
+      slug: true,
+      categories: true,
+      meta: true,
+      heroImage: true,
+      content: true,
+      relatedPosts: true,
+      populatedAuthors: true,
+      publishedAt: true,
+    },
     pagination: false,
     where: {
       slug: {

--- a/src/app/(frontend)/posts/page.tsx
+++ b/src/app/(frontend)/posts/page.tsx
@@ -24,6 +24,7 @@ export default async function Page() {
       slug: true,
       categories: true,
       meta: true,
+      heroImage: true,
     },
   })
 

--- a/src/app/(frontend)/posts/page/[pageNumber]/page.tsx
+++ b/src/app/(frontend)/posts/page/[pageNumber]/page.tsx
@@ -31,6 +31,13 @@ export default async function Page({ params: paramsPromise }: Args) {
     limit: 12,
     page: sanitizedPageNumber,
     overrideAccess: false,
+    select: {
+      title: true,
+      slug: true,
+      categories: true,
+      meta: true,
+      heroImage: true,
+    },
   })
 
   return (

--- a/src/app/(frontend)/search/page.tsx
+++ b/src/app/(frontend)/search/page.tsx
@@ -26,6 +26,7 @@ export default async function Page({ searchParams: searchParamsPromise }: Args) 
       slug: true,
       categories: true,
       meta: true,
+      heroImage: true,
     },
     // pagination: false reduces overhead if you don't need totalDocs
     pagination: false,

--- a/src/app/(frontend)/services/[slug]/page.tsx
+++ b/src/app/(frontend)/services/[slug]/page.tsx
@@ -94,6 +94,18 @@ const queryServiceBySlug = cache(async ({ slug }: { slug: string }) => {
     draft,
     limit: 1,
     overrideAccess: draft,
+    depth: 1,
+    select: {
+      title: true,
+      slug: true,
+      categories: true,
+      meta: true,
+      heroImage: true,
+      content: true,
+      relatedServices: true,
+      populatedAuthors: true,
+      publishedAt: true,
+    },
     pagination: false,
     where: {
       slug: {

--- a/src/app/(frontend)/services/page.tsx
+++ b/src/app/(frontend)/services/page.tsx
@@ -24,6 +24,7 @@ export default async function Page() {
       slug: true,
       categories: true,
       meta: true,
+      heroImage: true,
     },
   })
 

--- a/src/app/(frontend)/services/page/[pageNumber]/page.tsx
+++ b/src/app/(frontend)/services/page/[pageNumber]/page.tsx
@@ -31,6 +31,13 @@ export default async function Page({ params: paramsPromise }: Args) {
     limit: 12,
     page: sanitizedPageNumber,
     overrideAccess: false,
+    select: {
+      title: true,
+      slug: true,
+      categories: true,
+      meta: true,
+      heroImage: true,
+    },
   })
 
   return (

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -8,8 +8,8 @@ import type { Post, Service } from '@/payload-types'
 
 import { Media } from '@/components/Media'
 
-export type CardPostData = Pick<Post, 'slug' | 'categories' | 'meta' | 'title'>
-export type CardServiceData = Pick<Service, 'slug' | 'categories' | 'meta' | 'title'>
+export type CardPostData = Pick<Post, 'slug' | 'categories' | 'meta' | 'title' | 'heroImage'>
+export type CardServiceData = Pick<Service, 'slug' | 'categories' | 'meta' | 'title' | 'heroImage'>
 
 
 export const Card: React.FC<{
@@ -23,8 +23,9 @@ export const Card: React.FC<{
   const { card, link } = useClickableCard({})
   const { className, doc, relationTo, showCategories, title: titleFromProps } = props
 
-  const { slug, categories, meta, title } = doc || {}
+  const { slug, categories, meta, title, heroImage } = doc || {}
   const { description, image: metaImage } = meta || {}
+  const imageToUse = metaImage || heroImage
 
   const hasCategories = categories && Array.isArray(categories) && categories.length > 0
   const titleToUse = titleFromProps || title
@@ -40,8 +41,10 @@ export const Card: React.FC<{
       ref={card.ref}
     >
       <div className="relative w-full ">
-        {!metaImage && <div className="">No image</div>}
-        {metaImage && typeof metaImage !== 'string' && <Media resource={metaImage} size="33vw" />}
+        {!imageToUse && <div className="">No image</div>}
+        {imageToUse && typeof imageToUse !== 'string' && (
+          <Media resource={imageToUse} size="33vw" />
+        )}
       </div>
       <div className="p-4">
         {showCategories && hasCategories && (


### PR DESCRIPTION
## Summary
- extend `Card` prop types to include `heroImage`
- display `heroImage` when `meta.image` is not present
- request `heroImage` for service and post archives and detail queries
- query `heroImage` in search results

## Testing
- `pnpm run test:int` *(fails: cross-env not found / no internet)*

------
https://chatgpt.com/codex/tasks/task_e_6881d8178f9c832c81e6dae979159992